### PR TITLE
Fixes the default action for plugins

### DIFF
--- a/resources/plugin.rb
+++ b/resources/plugin.rb
@@ -7,5 +7,5 @@ attribute :collectors_path, :kind_of => String, :default => "/opt/diamond/etc/di
 
 def initialize(*args)
   super
-  @action = :create
+  @action = :enable
 end


### PR DESCRIPTION
The only valid actions are :enable and :disable, while the plugin resource defaults to :create. This changes the default to :enable.
