### PR TITLE
Update docs to reflecte the bump of psutil in a7c0dca

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Attribute Parameters:
     <td>required_python_packages</td>
     <td>Hash</td>
     <td>List of python packages to install for Diamond</td>
-    <td><tt><code>{ "configobj" => "4.7.2","psutil" => "0.6.1"}></code></tt></td>
+    <td><tt><code>{ "configobj" => "4.7.2","psutil" => "1.2.1"}></code></tt></td>
   </tr>
   <tr>
     <td>cookbook</td>

--- a/doc/chef/diamond.html
+++ b/doc/chef/diamond.html
@@ -152,7 +152,7 @@
     <td>required_python_packages</td>
     <td>Hash</td>
     <td>List of python packages to install for Diamond</td>
-    <td><tt><code>{ "configobj" => "4.7.2","psutil" => "0.6.1"}></code></tt></td>
+    <td><tt><code>{ "configobj" => "4.7.2","psutil" => "1.2.1"}></code></tt></td>
   </tr>
   <tr>
     <td>cookbook</td>

--- a/doc/file.README.html
+++ b/doc/file.README.html
@@ -148,7 +148,7 @@
     <td>required_python_packages</td>
     <td>Hash</td>
     <td>List of python packages to install for Diamond</td>
-    <td><tt><code>{ "configobj" => "4.7.2","psutil" => "0.6.1"}></code></tt></td>
+    <td><tt><code>{ "configobj" => "4.7.2","psutil" => "1.2.1"}></code></tt></td>
   </tr>
   <tr>
     <td>cookbook</td>

--- a/doc/index.html
+++ b/doc/index.html
@@ -148,7 +148,7 @@
     <td>required_python_packages</td>
     <td>Hash</td>
     <td>List of python packages to install for Diamond</td>
-    <td><tt><code>{ "configobj" => "4.7.2","psutil" => "0.6.1"}></code></tt></td>
+    <td><tt><code>{ "configobj" => "4.7.2","psutil" => "1.2.1"}></code></tt></td>
   </tr>
   <tr>
     <td>cookbook</td>


### PR DESCRIPTION
In a7c0dca, pip psutil have been bumped, but the docs are not up to date.
This simple commit fixes the docs.
